### PR TITLE
Fix some problems with loading via webclient

### DIFF
--- a/A0_ESP.ino
+++ b/A0_ESP.ino
@@ -31,7 +31,7 @@
 //      display patterns per tables in EEPROM
 
 //version number
-  #define VERSION 0x0004
+  #define VERSION 0x0005
 
 //login information for HTTP server
   const char* ssid = "your_ssid";
@@ -56,7 +56,11 @@
   
 //global variables
   uint8_t Execute;
-  String WebOutput = "";
+
+// Used to report to the browser; see D0_ReadPrint
+  const int MaxWebQueueSize = 10;
+  int WebQueueSize = 0;
+  String WebQueue[MaxWebQueueSize];
 
 //profile parameters
   uint8_t  State[36];
@@ -98,6 +102,9 @@ void setup()
   Serial.begin(115200);
   Wire.begin(0, 2);        //ESP8266 SDA=0 and SCL=2
   Wire.setClock(400000L);  //400Khz
+
+  // See D0_ReadPrint
+  InitializeWebQueue();
 
   //initialize PWM
   InitializePWM();

--- a/A3_WebServer.ino
+++ b/A3_WebServer.ino
@@ -18,7 +18,7 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 
-String main_page = "<HTML><head><script src=\"https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js\"></script><script>$(function(){window.setInterval(get_status, 10);}); function get_status() {var request = new XMLHttpRequest();request.onreadystatechange = function(){if (request.readyState === 4  && request.status === 200){var elt = document.getElementById(\"status\");elt.innerHTML = request.responseText;}};request.open(\"GET\", \"curr\", true);request.send();}</script></head><p id=\"status\">No Status Yet Recieved</p><form method=\"POST\" enctype=\"multipart/form-data\" action=\"upload\"><input type=\"file\" name=\"filename\"><br /><input type=\"submit\" value=\"LET'S DO THIS\"></form></HTML>";
+String main_page = "<HTML><head><script src=\"https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js\"></script><script>$(function(){window.setInterval(get_status, 1000);}); function get_status() {var request = new XMLHttpRequest();request.onreadystatechange = function(){if (request.readyState === 4  && request.status === 200){var elt = document.getElementById(\"status\");elt.innerHTML = request.responseText;console.log(request.responseText);}};request.open(\"GET\", \"curr\", true);request.send();}</script></head><form method=\"POST\" enctype=\"multipart/form-data\" action=\"upload\"><input type=\"file\" name=\"filename\"><br /><input type=\"submit\" value=\"Upload pattern\"></form><div class=\"status_container\"><div class=\"status_header\">Recent statuses (most recent at top):</div> </ br><div id=\"status\">No Status Yet Recieved</div></div></HTML>";
 
 // These are used during conversion of ASCII hex to bytes
 unsigned int line_number = 1;
@@ -271,7 +271,12 @@ void HandleUploadRequest()
 void HandleCurrStatus()
 {
   // WebOutput is defined in A0_ESP managed in D0_ReadWrite
-  server.send(200, "text/plain", WebOutput);
+  int j;
+  String output = "";
+  for(j=0; j<WebQueueSize; ++j){
+    output += "<p>" + WebQueue[j] + "</p>";
+  }
+  server.send(200, "text/plain", output);
 }
 
 void StartWebServer(ESP8266WebServer &server)

--- a/A3_WebServer.ino
+++ b/A3_WebServer.ino
@@ -160,12 +160,15 @@ String AsciiToBytes(uint8_t* ascii, int len)
       break;
       case ' ':
         // Whitespace; ignore.
+        continue;
       break;
       case '\t':
         // Whitespace; ignore.
+        continue;
       break;
       case '\r':
         // Whitspace; ignore.
+        continue;
       break;
       default:
         Serial.printf(

--- a/D0_ReadPrint.ino
+++ b/D0_ReadPrint.ino
@@ -2,7 +2,8 @@
 //  ReadPatternRecord()
 //  GetPatternName()
 //  
-//  WebPrint()
+//  InitializeWebQueue()
+//  WebPrint(String output)
 //
 //  GetCheckHeading()
 //  GetCheckRecord()
@@ -61,10 +62,30 @@ String GetPatternName(void)
   return PatternName;
 }
 
+void InitializeWebQueue(){
+  int j;
+  for(j=0; j<MaxWebQueueSize; ++j){
+    WebQueue[j] = "";
+  }
+}
+
 void WebPrint(String output)
 {
-  WebOutput = output;
-  Serial.print(output);  
+  Serial.print(output);
+
+  if(WebQueueSize >= MaxWebQueueSize)
+  {
+    int j;
+    for(j=MaxWebQueueSize-2; j>=0; --j)
+    {
+      WebQueue[j+1] = WebQueue[j];
+    }
+    WebQueue[0] = output;
+  }
+  else
+  {
+    WebQueue[WebQueueSize++] = output;
+  }
 }
 
 String GetCheckHeading(void)


### PR DESCRIPTION
I realized that the blank cases in the switch statement were leading to writing an extra blank character when no action should have been taken. Now that we have continue statements, ignoring the character is ignoring the character.
