### PR TITLE
Resolved issues that can arise when upload blocks occurr mid-line.

### DIFF
--- a/A0_ESP.ino
+++ b/A0_ESP.ino
@@ -5,7 +5,7 @@ Snowflakes WiFi
 ********************************************************/
 
 //version number
-  #define VERSION 0x0007
+  #define VERSION 0x0008
 
 //includes
   #include <Wire.h>


### PR DESCRIPTION
Okay, I fixed it.

When you upload a file, it gets uploaded in multiple blocks. It looks like the default size of a block is 2048 bytes. Wherever the 2048th byte is, the line will be drawn. I relied on state to be preserved between every two newlines, but that's evidently a fallacy. The two particular issues you guys identified were both the result of the boundaries of upload blocks falling in the middle of a line.

The first issue was splitting a line between two nibbles of the same byte. Previously, the first nibble would simply fall off the map, and the second nibble would be treated as the first nibble of the next byte. This would cause the last nibble of the line to be ignored, as the line would have an odd number of nibbles. Now, if we run out of characters in a block and we have a hanging nibble, we remember the nibble represented by the final character of the previous block and treat the first character of the next block as the second nibble of a byte beginning with the nibble we remembered.

The second issue was splitting a line in the middle of a comment. If the program sees a `#` at the start of a line, it ignores all the following characters until it reaches a newline character or the end of the upload block. Previously, if the end of the upload block was reached before we saw a newline, the first character of the next block would be treated as part of a table record, when in fact it was the continuation of a comment. Now, if we're skipping a comment run out of characters in the upload block before we see a newline, we remember that we're in the middle of a comment, and keep skipping characters in the next block until we do see a newline.
